### PR TITLE
eth_getBlockByNumber responses empty slice instead of null 

### DIFF
--- a/app/rpc/backend/backend.go
+++ b/app/rpc/backend/backend.go
@@ -160,8 +160,10 @@ func (b *EthermintBackend) GetBlockByNumber(blockNum rpctypes.BlockNumber, fullT
 	if err := json.Unmarshal(res, &ethBlock); err != nil {
 		return nil, err
 	}
-
-	if fullTx {
+	// return empty slice instead of null when there is no transactions in block
+	if ethBlock.TransactionsRoot == ethtypes.EmptyRootHash {
+		ethBlock.Transactions = []common.Hash{}
+	} else if fullTx {
 		ethTxs, err := b.getBlockFullTxs(height, ethBlock.Hash)
 		if err != nil {
 			return nil, err
@@ -200,8 +202,10 @@ func (b *EthermintBackend) GetBlockByHash(hash common.Hash, fullTx bool) (*evmty
 		if err := json.Unmarshal(res, &ethBlock); err != nil {
 			return nil, err
 		}
-
-		if fullTx {
+		// return empty slice instead of null when there is no transactions in block
+		if ethBlock.TransactionsRoot == ethtypes.EmptyRootHash {
+			ethBlock.Transactions = []common.Hash{}
+		} else if fullTx {
 			ethTxs, err := b.getBlockFullTxs(int64(ethBlock.Number), ethBlock.Hash)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
… is no transactions in block

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okx/okbchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okx/coding/blob/master/README.md#merging-a-pr))
